### PR TITLE
Missing cuke4duke gem

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,10 +1,10 @@
-(defproject lein-cuke "0.0.2"
+(defproject lein-cuke "0.0.3"
   :description "Cucumber runner for leiningen"
   :repositories {"cukes" "http://cukes.info/maven"
                  "clojars" "http://clojars.org/repo"}
   :dependencies [[org.clojure/clojure "1.2.0"]
                  [org.clojure/clojure-contrib "1.2.0"]
-                 [cuke4duke "0.4.3"
+                 [cuke4duke "0.4.4"
                   :exclusions [org.clojure/clojure
                                org.clojure/clojure-contrib]]]
   :dev-dependencies [[lein-clojars "0.5.0-SNAPSHOT"]])

--- a/src/leiningen/cuke_gems.clj
+++ b/src/leiningen/cuke_gems.clj
@@ -4,4 +4,4 @@
 (defn cuke-gems
   "Run cucumber features"
   [project]
-  (jruby "-S gem install -i lib/gems --no-rdoc --no-ri cucumber"))
+  (jruby "-S gem install -i lib/gems --no-rdoc --no-ri cucumber cuke4duke"))


### PR DESCRIPTION
Hi,

first of all thank you for your nice leiningen cuke plugin. I have tried to get started with cucumber, cuke4duke and Clojure quickly. lein-cuke was the easiest and quickest way to do that. I used https://github.com/mjul/cucumber-tutorial as tutorial and starting point. All things went well except that cucumber was not able to bind the Clojure files to the story text. However I'm new to Ruby and had a hard time to discover the reason for this error. Finally I run "lein-cuke --verbose" and see this error:

Failed to load 'clj' programming language for file features/step_definitions/open_position_steps.clj: no such file to load -- cucumber/clj_support/clj_language
- features/step_definitions/open_position_steps.clj [NOT SUPPORTED]

To fix this issue I have modified cuke-gem so that it also fetchs the cuke4duke gem to get the cuke4duke/lib/cucumber/clj_support/clj_language.rb which is need for the Cucumber Clojure support.

Cheers,

Max
